### PR TITLE
Secure users service

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -59,7 +59,7 @@ module.exports = {
   users: {
     roles: {
       // the first user added to an empty users file is made an administrator using these roles.
-      forFirstUser: 'superAdmin admin',
+      forFirstUser: ['superAdmin', 'admin'],
       // the default roles for a new user
       default: '',
       // roles allowed to change the roles of other users

--- a/server/services/user/hooks/index.js
+++ b/server/services/user/hooks/index.js
@@ -40,7 +40,7 @@ exports.before = (app) => {
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
         ownerField: idName,
-        owner: true
+        owner: true,
       }),
     ],
     create: [
@@ -62,7 +62,7 @@ exports.before = (app) => {
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
         ownerField: idName,
-        owner: true
+        owner: true,
       }),
     ],
     patch: [ // client route /user/rolechange patches roles. todo might check its an admin acct
@@ -73,7 +73,7 @@ exports.before = (app) => {
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
         ownerField: idName,
-        owner: true
+        owner: true,
       }),
     ],
     remove: [
@@ -84,7 +84,7 @@ exports.before = (app) => {
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
         ownerField: idName,
-        owner: true
+        owner: true,
       }),
     ],
   };

--- a/server/services/user/hooks/index.js
+++ b/server/services/user/hooks/index.js
@@ -39,7 +39,7 @@ exports.before = (app) => {
       // Only the owner (user) or admin can get a user
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
-        ownerField: '_id',
+        ownerField: idName,
         owner: true
       }),
     ],
@@ -61,7 +61,7 @@ exports.before = (app) => {
       // Only the owner (user) or admin can update a user
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
-        ownerField: '_id',
+        ownerField: idName,
         owner: true
       }),
     ],
@@ -72,7 +72,7 @@ exports.before = (app) => {
       // Only the owner (user) or admin can get a user
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
-        ownerField: '_id',
+        ownerField: idName,
         owner: true
       }),
     ],
@@ -83,7 +83,7 @@ exports.before = (app) => {
       // Only the owner (user) or admin can remove a user
       auth.restrictToRoles({
         roles: ['superAdmin', 'admin'],
-        ownerField: '_id',
+        ownerField: idName,
         owner: true
       }),
     ],

--- a/server/services/user/hooks/index.js
+++ b/server/services/user/hooks/index.js
@@ -25,12 +25,23 @@ exports.before = (app) => {
       auth.verifyToken(),
       auth.populateUser(),
       auth.restrictToAuthenticated(),
+      // Only allow admin to list all users
+      auth.restrictToRoles({
+        roles: ['superAdmin', 'admin'],
+        idField: idName,
+        owner: false,
+      }),
     ],
     get: [
       auth.verifyToken(),
       auth.populateUser(),
       auth.restrictToAuthenticated(),
-      auth.restrictToOwner({ ownerField: idName }),
+      // Only the owner (user) or admin can get a user
+      auth.restrictToRoles({
+        roles: ['superAdmin', 'admin'],
+        ownerField: '_id',
+        owner: true
+      }),
     ],
     create: [
       validateSchema.form(schemas.signup, schemas.options), // schema validation
@@ -47,18 +58,34 @@ exports.before = (app) => {
       auth.verifyToken(),
       auth.populateUser(),
       auth.restrictToAuthenticated(),
-      auth.restrictToOwner({ ownerField: idName }),
+      // Only the owner (user) or admin can update a user
+      auth.restrictToRoles({
+        roles: ['superAdmin', 'admin'],
+        ownerField: '_id',
+        owner: true
+      }),
     ],
     patch: [ // client route /user/rolechange patches roles. todo might check its an admin acct
       auth.verifyToken(),
       auth.populateUser(),
       auth.restrictToAuthenticated(),
+      // Only the owner (user) or admin can get a user
+      auth.restrictToRoles({
+        roles: ['superAdmin', 'admin'],
+        ownerField: '_id',
+        owner: true
+      }),
     ],
     remove: [
       auth.verifyToken(),
       auth.populateUser(),
       auth.restrictToAuthenticated(),
-      auth.restrictToOwner({ ownerField: idName }),
+      // Only the owner (user) or admin can remove a user
+      auth.restrictToRoles({
+        roles: ['superAdmin', 'admin'],
+        ownerField: '_id',
+        owner: true
+      }),
     ],
   };
 };


### PR DESCRIPTION
This corrects two issues
1. The first user that is created is assigned an array of roles.
2. Each service method for the user service is restricted such that the user can only access their own user record. There is an exception for users with the superAdmin or admin roles.