### PR TITLE
Fix npm start crash due to the absence of the logs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 data/
 data-dev/
 # log folders
-logs/
 logs-dev/
 # builds
 public/dist/

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Actually there is a problem when you try to start the project after a build because there is no logs folder. It is easy to reproduce, just clone the repository and do: npm install && npm start.

This commit add the logs folder and ignore everything inside it.